### PR TITLE
Cambie usuario por nombre y apellido para corregir bug de userID en vista

### DIFF
--- a/apps/votos/templates/charla/detalle.html
+++ b/apps/votos/templates/charla/detalle.html
@@ -13,7 +13,7 @@
   <div class="col s12">
     <div class="card-panel grey lighten-4">
       <h4 class="card-title grey-text text-darken-4">{{ charla.titulo }}</h4>
-      <p class="grey-text label">Posteado por: {{ charla.usuario }}</p>
+      <p class="grey-text label">Posteado por: {{ charla.usuario.first_name }} {{ charla.usuario.last_name }}</p>
       <p class="grey-text label">
       	Fecha publicación: {{ charla.fecha_publicacion}}
       </p>

--- a/apps/votos/templates/charla/index.html
+++ b/apps/votos/templates/charla/index.html
@@ -23,7 +23,7 @@
                 <i class="material-icons amber-text text-accent-2">grade</i><span class="grey-text">{{ charla.votos }}</span>
                 <!-- <i class="material-icons blue-text">comment</i><span class="grey-text">5</span> -->
               </div>
-              <p class="grey-text label">Posteado por: {{ charla.usuario }}</p>
+              <p class="grey-text label">Posteado por: {{ charla.usuario.first_name }} {{ charla.usuario.last_name }}</p>
               <p class="grey-text label">
               	{{ charla.fecha_publicacion}}
               </p>


### PR DESCRIPTION
Coloque nombre y apellido de usuario que postula la charla para quitar el user id que aparecia en la plantilla. Fixes #85